### PR TITLE
Update post holder details

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -7,7 +7,7 @@ title: About CRUx
 
 - Email : [crux@hyderabad.bits-pilani.ac.in](mailto:crux@hyderabad.bits-pilani.ac.in)
 - Post holders' cell-phone numbers:
-  - Ujjwal Raizada ( President ) [7897745889](tel:7897745889)
-  - Krut Patel ( Secretary ) [8320281468](tel:8320281468)
-  - Kunal Verma ( Secretary ) [7730847399](tel:7730847399)
+  - Harshvardhan Jha ( President ) [9971683937](tel:9971683937)
+  - Divyanshu Agrawal ( Secretary ) [9521738499](tel:9521738499)
+  - Pranav Rajagopalan ( Secretary ) [8861616947](tel:8861616947)
 - Crux facebook page : [https://www.facebook.com/cruxbphc/](https://www.facebook.com/cruxbphc/)

--- a/index.html
+++ b/index.html
@@ -64,9 +64,9 @@
                     college. We also strive to make things on campus easier and
                     more convenient via the means of code.
                     <br><br>
-                    The post holders for this year ( 2019-20 ) are Ujjwal
-                    Raizada - President, Krut Patel - Secretary
-                    and Kunal Verma - Secretary.
+                    The post holders for this year ( 2020-21 ) are Harshvardhan
+                    Jha - President, Divyanshu Agrawal - Secretary
+                    and Pranav Rajagopalan - Secretary.
                     <br><br>
                     <a href="./contact" class="btn btn-primary"><i
                             class="fa fa-envelope"></i> &nbsp;Connect


### PR DESCRIPTION
The page still had the 2019-20 posts holders listed. I updated the names and tenure as well as the contact details.